### PR TITLE
Guard options file when SuperAPI failed to load

### DIFF
--- a/SuperAPIOptions.lua
+++ b/SuperAPIOptions.lua
@@ -1,5 +1,5 @@
 -- No superwow, no superapi
-if not SetAutoloot then
+if not SuperAPI then
 	return
 end
 


### PR DESCRIPTION
Fixes #22.

SuperAPI.lua bails out early when SUPERWOW_VERSION is missing or below 2.2, so the SuperAPI global never gets created. SuperAPIOptions.lua guards on `SetAutoloot` instead, which can be present in that situation, so it runs anyway and throws `attempt to index global 'SuperAPI' (a nil value)` on the first SuperAPI.* line. Checking for SuperAPI directly makes the options file bail under the exact same condition as the core.